### PR TITLE
Add methods to manage Git annotated tags

### DIFF
--- a/src/command_modules/vsts-cli-code/vsts/cli/code/_format.py
+++ b/src/command_modules/vsts-cli-code/vsts/cli/code/_format.py
@@ -254,3 +254,17 @@ def _transform_repo_row(row):
 
 def _get_repo_key(repo_row):
     return repo_row['name']
+
+
+def transform_tag_table_output(result):
+    table_output = [_transform_tag_row(result)]
+    return table_output
+
+
+def _transform_tag_row(row):
+    table_row = OrderedDict()
+    table_row['ID'] = row['objectId']
+    table_row['Name'] = row['name']
+    if row['message']:
+        table_row['Message'] = row['message']
+    return table_row

--- a/src/command_modules/vsts-cli-code/vsts/cli/code/_help.py
+++ b/src/command_modules/vsts-cli-code/vsts/cli/code/_help.py
@@ -42,3 +42,9 @@ helps['code repo'] = """
     short-summary: Manage repositories.
     long-summary:
 """
+
+helps['code tag'] = """
+    type: group
+    short-summary: Manage annotated tags.
+    long-summary:
+"""

--- a/src/command_modules/vsts-cli-code/vsts/cli/code/arguments.py
+++ b/src/command_modules/vsts-cli-code/vsts/cli/code/arguments.py
@@ -38,7 +38,7 @@ def load_code_arguments(cli_command_loader):
 
     with ArgumentsContext(cli_command_loader, 'code pr work-items') as ac:
         ac.argument('work_items', nargs='+')
-        
+
     with ArgumentsContext(cli_command_loader, 'code pr update') as ac:
         ac.argument('auto_complete', **enum_choice_list(_ON_OFF_SWITCH_VALUES))
         ac.argument('squash', **enum_choice_list(_ON_OFF_SWITCH_VALUES))
@@ -53,3 +53,11 @@ def load_code_arguments(cli_command_loader):
 
     with ArgumentsContext(cli_command_loader, 'code repo') as ac:
         ac.argument('repo_id', options_list='--id')
+
+    with ArgumentsContext(cli_command_loader, 'code tag') as ac:
+        ac.argument('repository', options_list=('--repository', '-r'))
+        ac.argument('object-id', options_list=('--object-id'))
+
+    with ArgumentsContext(cli_command_loader, 'code tag create') as ac:
+        ac.argument('name', options_list=('--name', '-n'))
+        ac.argument('message', options_list=('--message', '-m'))

--- a/src/command_modules/vsts-cli-code/vsts/cli/code/commands.py
+++ b/src/command_modules/vsts-cli-code/vsts/cli/code/commands.py
@@ -12,6 +12,7 @@ from ._format import (transform_pull_request_table_output,
                       transform_reviewer_table_output,
                       transform_policies_table_output,
                       transform_policy_table_output,
+                      transform_tag_table_output,
                       transform_work_items_table_output)
 
 
@@ -62,3 +63,7 @@ def load_code_commands(cli_command_loader):
         g.command('repo create', 'repository#create_repo', table_transformer=transform_repo_table_output)
         g.command('repo list', 'repository#list_repos', table_transformer=transform_repos_table_output)
         g.command('repo show', 'repository#show_repo', table_transformer=transform_repo_table_output)
+
+        # tag commands
+        g.command('tag create', 'tag#create_tag', table_transformer=transform_tag_table_output)
+        g.command('tag show', 'tag#show_tag', table_transformer=transform_tag_table_output)

--- a/src/common_modules/vsts-cli-code-common/vsts/cli/code/common/tag.py
+++ b/src/common_modules/vsts-cli-code-common/vsts/cli/code/common/tag.py
@@ -1,0 +1,51 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from vsts.git.v4_0.models.git_annotated_tag import GitAnnotatedTag
+from vsts.git.v4_0.models.git_version_descriptor import GitVersionDescriptor
+from vsts.git.v4_0.models.git_object import GitObject
+from vsts.cli.common.exception_handling import handle_command_exception
+from vsts.cli.common.services import (get_git_client,
+                                      resolve_instance,
+                                      resolve_instance_project_and_repo)
+
+
+def create_tag(name, object_id, message=None, repository=None, project=None, team_instance=None, detect=None):
+    """Create a tag.
+    :param str name: Name of the annotated tag.
+    :param str object_id: ID of the object the tag is pointing to.
+    :param str message: Message of the annotated tag.
+    :param str project: Name or ID of the team project.
+    :param str repository: Name or ID of the repository to create the tag in.
+    """
+    try:
+        team_instance, project, repository = resolve_instance_project_and_repo(
+            detect=detect, team_instance=team_instance, project=project, repo=repository)
+        client = get_git_client(team_instance)
+
+        tagged_object = GitObject(object_id)
+        tag = GitAnnotatedTag(name=name,
+                              message=message,
+                              tagged_object=tagged_object)
+        return client.create_annotated_tag(tag, project, repository)
+    except Exception as ex:
+        handle_command_exception(ex)
+
+
+def show_tag(object_id, repository=None, project=None, team_instance=None, detect=None):
+    """Get the details of a tag.
+    :param str object_id: ID of the tag.
+    :param str project: Name or ID of the team project.
+    :param str repository: Name or ID of the repository.
+    """
+    try:
+        team_instance, project, repository = resolve_instance_project_and_repo(
+            detect=detect, team_instance=team_instance, project=project, repo=repository)
+        client = get_git_client(team_instance)
+        return client.get_annotated_tag(project=project,
+                                        repository_id=repository,
+                                        object_id=object_id)
+    except Exception as ex:
+        handle_command_exception(ex)

--- a/src/common_modules/vsts-cli-code-common/vsts/cli/code/common/tag.py
+++ b/src/common_modules/vsts-cli-code-common/vsts/cli/code/common/tag.py
@@ -12,13 +12,15 @@ from vsts.cli.common.services import (get_git_client,
                                       resolve_instance_project_and_repo)
 
 
-def create_tag(name, object_id, message=None, repository=None, project=None, team_instance=None, detect=None):
+def create_tag(name, object_id, message=None, repository=None, team_instance=None, project=None, detect=None):
     """Create a tag.
     :param str name: Name of the annotated tag.
     :param str object_id: ID of the object the tag is pointing to.
     :param str message: Message of the annotated tag.
-    :param str project: Name or ID of the team project.
-    :param str repository: Name or ID of the repository to create the tag in.
+    :param str repository: Name or ID of the repository.
+    :param str team_instance: The URI for the VSTS account (https://<account>.visualstudio.com) or your TFS project collection.
+    :param str project: Name or ID of the project.
+    :param str detect: When 'On' unsupplied arg values will be detected from the current working directory's repo.
     """
     try:
         team_instance, project, repository = resolve_instance_project_and_repo(
@@ -34,11 +36,13 @@ def create_tag(name, object_id, message=None, repository=None, project=None, tea
         handle_command_exception(ex)
 
 
-def show_tag(object_id, repository=None, project=None, team_instance=None, detect=None):
+def show_tag(object_id, repository=None, team_instance=None, project=None, detect=None):
     """Get the details of a tag.
     :param str object_id: ID of the tag.
-    :param str project: Name or ID of the team project.
     :param str repository: Name or ID of the repository.
+    :param str team_instance: The URI for the VSTS account (https://<account>.visualstudio.com) or your TFS project collection.
+    :param str project: Name or ID of the project.
+    :param str detect: When 'On' unsupplied arg values will be detected from the current working directory's repo.
     """
     try:
         team_instance, project, repository = resolve_instance_project_and_repo(


### PR DESCRIPTION
Add methods to manage Git annotated tags:

- create
- show

Deleting an annotated tag can be achieved with with the `vsts code ref delete` command

Work related to the issue #119 