### PR TITLE
add methods to create and list pr status.

### DIFF
--- a/src/command_modules/vsts-cli-code/vsts/cli/code/_help.py
+++ b/src/command_modules/vsts-cli-code/vsts/cli/code/_help.py
@@ -31,6 +31,12 @@ helps['code pr reviewers'] = """
     long-summary:
 """
 
+helps['code pr statuses'] = """
+    type: group
+    short-summary: Manage pull request statuses.
+    long-summary:
+"""
+
 helps['code pr work-items'] = """
     type: group
     short-summary: Manage work items associated with pull requests.

--- a/src/command_modules/vsts-cli-code/vsts/cli/code/commands.py
+++ b/src/command_modules/vsts-cli-code/vsts/cli/code/commands.py
@@ -43,6 +43,10 @@ def load_code_commands(cli_command_loader):
         g.command('pr reviewers remove', 'pull_request#delete_pull_request_reviewers',
                   table_transformer=transform_reviewers_table_output)
 
+        # pr status commands
+        g.command('pr statuses list', 'pull_request#list_pull_request_statuses')
+        g.command('pr statuses create', 'pull_request#create_pull_request_status')
+
         # pr work item commands
         g.command('pr work-items add', 'pull_request#add_pull_request_work_items',
                   table_transformer=transform_work_items_table_output)


### PR DESCRIPTION
Add methods to create and list a pull request's statuses.

List the statuses (see `vsts code pr statuses list -h` for the options):

    vsts code pr statuses list --repository [repository] --id [ID]

Create a status (see `vsts code pr statuses create -h for the options` for the options):

    vsts code pr statuses create --repository [repository] --id [ID] --state [state] --name [name]

Related to issue #78