### PR TITLE
add support to pass secrets in interactive mode without params

### DIFF
--- a/azure-devops/azext_devops/dev/team/service_endpoint.py
+++ b/azure-devops/azext_devops/dev/team/service_endpoint.py
@@ -6,6 +6,7 @@
 from __future__ import print_function
 
 from knack.log import get_logger
+from knack.prompting import prompt_pass, NoTTYException
 from knack.util import CLIError
 from azext_devops.vstsCompressed.service_endpoint.v4_1.models.models import ServiceEndpoint
 from azext_devops.vstsCompressed.service_endpoint.v4_1.models.models import EndpointAuthorization
@@ -81,6 +82,12 @@ def create_service_endpoint(service_endpoint_type, authorization_scheme, name,
 
     if (service_endpoint_type == SERVICE_ENDPOINT_TYPE_GITHUB and
             authorization_scheme == SERVICE_ENDPOINT_AUTHORIZATION_PERSONAL_ACCESS_TOKEN):
+        if not github_access_token:
+            try:
+                github_access_token = prompt_pass('GitHub access token:', confirm=True)
+            except NoTTYException:
+                raise CLIError('Please specify --github-access-token in non-interactive mode.')
+
         service_endpoint_authorization = EndpointAuthorization(
             parameters={'accessToken': github_access_token},
             scheme=SERVICE_ENDPOINT_AUTHORIZATION_PERSONAL_ACCESS_TOKEN)
@@ -91,6 +98,11 @@ def create_service_endpoint(service_endpoint_type, authorization_scheme, name,
 
     if (service_endpoint_type == SERVICE_ENDPOINT_TYPE_AZURE_RM and
             authorization_scheme == SERVICE_ENDPOINT_AUTHORIZATION_SERVICE_PRINCIPAL):
+        if not azure_rm_service_prinicipal_key:
+            try:
+                azure_rm_service_prinicipal_key = prompt_pass('Azure RM service principal key:', confirm=True)
+            except NoTTYException:
+                raise CLIError('Please specify --azure-rm-service-prinicipal-key in non-interactive mode.')
         service_endpoint_authorization = EndpointAuthorization(
             parameters={'tenantid': azure_rm_tenant_id,
                         'serviceprincipalid': azure_rm_service_principal_id,

--- a/azure-devops/azext_devops/test/team/test_service_endpoint.py
+++ b/azure-devops/azext_devops/test/team/test_service_endpoint.py
@@ -72,6 +72,7 @@ class TestServiceEndpointMethods(unittest.TestCase):
         response = create_service_endpoint(service_endpoint_type = SERVICE_ENDPOINT_TYPE_GITHUB, 
                                            authorization_scheme = SERVICE_ENDPOINT_AUTHORIZATION_PERSONAL_ACCESS_TOKEN, 
                                            name = '',
+                                           github_access_token = 'fake',
                                            organization = self._TEST_DEVOPS_ORGANIZATION,
                                            project = self._TEST_PROJECT_NAME)
 
@@ -83,6 +84,7 @@ class TestServiceEndpointMethods(unittest.TestCase):
         response = create_service_endpoint(service_endpoint_type = SERVICE_ENDPOINT_TYPE_AZURE_RM, 
                                            authorization_scheme = SERVICE_ENDPOINT_AUTHORIZATION_SERVICE_PRINCIPAL, 
                                            name = '',
+                                           azure_rm_service_prinicipal_key = 'fake',
                                            organization = self._TEST_DEVOPS_ORGANIZATION,
                                            project = self._TEST_PROJECT_NAME)
 


### PR DESCRIPTION
Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [ ] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.

[This](https://github.com/Azure/azure-cli/blob/beb3ccf7a555db7ec108862d011de5cb51f045c0/src/command_modules/azure-cli-dla/azure/cli/command_modules/dla/custom.py#L177) is how even azure CLI is doing this

This is for fixing https://github.com/Microsoft/azure-devops-cli-extension/issues/437 