### PR TITLE
Remove repo auto detect to avoid passing repository in projectwiki create

### DIFF
--- a/azure-devops/azext_devops/dev/team/arguments.py
+++ b/azure-devops/azext_devops/dev/team/arguments.py
@@ -17,6 +17,7 @@ from .const import (SERVICE_ENDPOINT_AUTHORIZATION_PERSONAL_ACCESS_TOKEN,
 _YES_NO_SWITCH_VALUES = ['yes', 'no']
 _SOURCE_CONTROL_VALUES = ['git', 'tfvc']
 _WIKI_TYPE_VALUES = ['projectwiki', 'codewiki']
+_WIKI_LIST_SCOPE_VALUES = ['project', 'organization']
 _PROJECT_VISIBILITY_VALUES = ['private', 'public']
 _STATE_VALUES = ['invalid', 'unchanged', 'all', 'new', 'wellformed', 'deleting', 'createpending']
 _SERVICE_ENDPOINT_TYPE = [SERVICE_ENDPOINT_TYPE_GITHUB, SERVICE_ENDPOINT_TYPE_AZURE_RM]
@@ -117,3 +118,6 @@ def load_team_arguments(self, _):
     with self.argument_context('devops wiki') as context:
         context.argument('wiki_type', options_list=('--wiki-type', '--type'), **enum_choice_list(_WIKI_TYPE_VALUES))
         context.argument('version', options_list=('--version', '-v'))
+
+    with self.argument_context('devops wiki list') as context:
+        context.argument('scope', **enum_choice_list(_WIKI_LIST_SCOPE_VALUES))

--- a/azure-devops/azext_devops/dev/team/wiki.py
+++ b/azure-devops/azext_devops/dev/team/wiki.py
@@ -27,7 +27,8 @@ def create_wiki(name, wiki_type='projectwiki', mapped_path=None, version=None,
     :type wiki_type: str
     :param version: [Required for codewiki type] Repository branch name to publish the code wiki from.
     :type version: str
-    :param mapped_path: [Required for codewiki type] Mapped path of the new wiki e.g. '/' to publish from root of repository.
+    :param mapped_path: [Required for codewiki type] Mapped path of the new wiki
+    e.g. '/' to publish from root of repository.
     :type mapped_path: str
     :param repository: [Required for codewiki type] Name or ID of the repository to publish the wiki from.
     :type repository: str

--- a/azure-devops/azext_devops/dev/team/wiki.py
+++ b/azure-devops/azext_devops/dev/team/wiki.py
@@ -9,7 +9,8 @@ from azext_devops.dev.common.services import (get_wiki_client,
                                               get_core_client,
                                               get_git_client,
                                               resolve_instance,
-                                              resolve_instance_and_project)
+                                              resolve_instance_and_project,
+                                              resolve_instance_project_and_repo)
 
 
 _DEFAULT_PAGE_ADD_MESSAGE = 'Added a new page using Azure DevOps CLI'
@@ -24,18 +25,27 @@ def create_wiki(name, wiki_type='projectwiki', mapped_path=None, version=None,
     :type name: str
     :param wiki_type: Type of wiki to create.
     :type wiki_type: str
-    :param version: Repository branch name to publish the code wiki from. Only required for codewiki type.
+    :param version: [Required for codewiki type] Repository branch name to publish the code wiki from.
     :type version: str
-    :param mapped_path: Mapped path of the new wiki e.g. '/' to publish from root of repository.
-    Only required for codewiki type.
+    :param mapped_path: [Required for codewiki type] Mapped path of the new wiki e.g. '/' to publish from root of repository.
     :type mapped_path: str
-    :param repository: Name or ID of the repository to publish the wiki from. Only required for codewiki type.
+    :param repository: [Required for codewiki type] Name or ID of the repository to publish the wiki from.
     :type repository: str
     """
-    organization, project = resolve_instance_and_project(detect=detect,
-                                                         organization=organization,
-                                                         project=project,
-                                                         project_required=True)
+    repository_id = None
+    if wiki_type == 'codewiki':
+        organization, project, repository = resolve_instance_project_and_repo(detect=detect,
+                                                                              organization=organization,
+                                                                              project=project,
+                                                                              repo=repository,
+                                                                              repo_required=True)
+        repository_id = _get_repository_id_from_name(organization=organization,
+                                                     project=project,
+                                                     repository=repository)
+    else:
+        organization, project = resolve_instance_and_project(detect=detect,
+                                                             organization=organization,
+                                                             project=project)
     wiki_client = get_wiki_client(organization)
     from azext_devops.devops_sdk.v5_0.wiki.models import WikiCreateParametersV2
     wiki_params = WikiCreateParametersV2()
@@ -44,9 +54,6 @@ def create_wiki(name, wiki_type='projectwiki', mapped_path=None, version=None,
     project_id = _get_project_id_from_name(organization=organization,
                                            project=project)
     wiki_params.project_id = project_id
-    repository_id = _get_repository_id_from_name(organization=organization,
-                                                 project=project,
-                                                 repository=repository)
     wiki_params.repository_id = repository_id
     if mapped_path:
         wiki_params.mapped_path = mapped_path
@@ -70,11 +77,18 @@ def delete_wiki(wiki, organization=None, project=None, detect=None):
     return wiki_client.delete_wiki(wiki_identifier=wiki, project=project)
 
 
-def list_wiki(organization=None, project=None, detect=None):
+def list_wiki(scope='project', organization=None, project=None, detect=None):
     """List all the wikis in a project or organization.
+    :param scope: List the wikis at project or organization level.
+    :type scope: str
     """
-    organization = resolve_instance(detect=detect,
-                                    organization=organization)
+    if scope == 'project':
+        organization, project = resolve_instance_and_project(detect=detect,
+                                                             organization=organization,
+                                                             project=project)
+    else:
+        organization = resolve_instance(detect=detect,
+                                        organization=organization)
     wiki_client = get_wiki_client(organization)
     return wiki_client.get_all_wikis(project=project)
 

--- a/azure-devops/azext_devops/dev/team/wiki.py
+++ b/azure-devops/azext_devops/dev/team/wiki.py
@@ -9,8 +9,7 @@ from azext_devops.dev.common.services import (get_wiki_client,
                                               get_core_client,
                                               get_git_client,
                                               resolve_instance,
-                                              resolve_instance_and_project,
-                                              resolve_instance_project_and_repo)
+                                              resolve_instance_and_project)
 
 
 _DEFAULT_PAGE_ADD_MESSAGE = 'Added a new page using Azure DevOps CLI'
@@ -33,10 +32,10 @@ def create_wiki(name, wiki_type='projectwiki', mapped_path=None, version=None,
     :param repository: Name or ID of the repository to publish the wiki from. Only required for codewiki type.
     :type repository: str
     """
-    organization, project, repository = resolve_instance_project_and_repo(detect=detect,
-                                                                          organization=organization,
-                                                                          project=project,
-                                                                          repo=repository)
+    organization, project = resolve_instance_and_project(detect=detect,
+                                                         organization=organization,
+                                                         project=project,
+                                                         project_required=True)
     wiki_client = get_wiki_client(organization)
     from azext_devops.devops_sdk.v5_0.wiki.models import WikiCreateParametersV2
     wiki_params = WikiCreateParametersV2()


### PR DESCRIPTION
If we auto detect repository we will need to pass --repository ' ' while creating project wiki else it fails. 
With this change --repository will only need to be passed with code wiki and not project wiki.

Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [ ] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.
